### PR TITLE
Fix notebook copy location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN useradd -m jupyter
 USER jupyter
 WORKDIR /home/jupyter
 
-COPY notebook ./
+COPY notebook ./notebook
 COPY run.sh ./
 
 WORKDIR /home/jupyter/notebook


### PR DESCRIPTION
Because Docker really needed to invent their own semantics for copy instead of just copying unix.