### PR TITLE
Use a virtualenv so packages can be installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,19 @@
 FROM python:latest
 
-COPY requirements.txt ./
-RUN pip install -r requirements.txt
-
 RUN useradd -m jupyter
 USER jupyter
 WORKDIR /home/jupyter
 
+RUN python3 -m venv notebook-env
+COPY --chown=jupyter requirements.txt ./
+
+RUN /home/jupyter/notebook-env/bin/pip install --upgrade pip
+RUN /home/jupyter/notebook-env/bin/pip install -r requirements.txt
+
 COPY --chown=jupyter notebook ./notebook
 COPY run.sh ./
+
+ENV PATH=/home/jupyter/notebook-env/bin:$PATH
 
 WORKDIR /home/jupyter/notebook
 

--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-jupyter notebook --generate-config
+set -e
+
+/home/jupyter/notebook-env/bin/jupyter notebook --generate-config
 
 # protect your notebook with a password on the following line:
 JUPYTER_NOTEBOOK_PASSWORD=""
@@ -13,4 +15,4 @@ echo "c.NotebookApp.default_url = '/notebooks/$NOTEBOOK'" >> ~/.jupyter/jupyter_
 # to embed the jupyter notebook in an iframe, uncomment the following line and edit your domain
 # echo "c.NotebookApp.tornado_settings = {'headers': {'Content-Security-Policy': 'frame-ancestors \'self\' [YOUR DOMAIN];'}}" >> ~/.jupyter/jupyter_notebook_config.py
 
-jupyter notebook --ip 0.0.0.0 --port $PORT --no-browser
+/home/jupyter/notebook-env/bin/jupyter notebook --ip 0.0.0.0 --port $PORT --no-browser


### PR DESCRIPTION
Previously, the Python environment inside the container was owned by `root` but ran as `jupyter`, which meant that package installation didn't work as expected. We could fix this for package installation by adding a local directory to `PYTHONPATH`, but using a virtualenv feels simpler.